### PR TITLE
Qt5 -> Qt6 Compatability

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.7
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects
 import SddmComponents 2.0
 
 import "slice"

--- a/slice/LoopListPowerItem.qml
+++ b/slice/LoopListPowerItem.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.7
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects
 
 Item
 {

--- a/slice/LoopListSessionItem.qml
+++ b/slice/LoopListSessionItem.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.7
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects
 import SddmComponents 2.0
 
 Item

--- a/slice/LoopListUserItem.qml
+++ b/slice/LoopListUserItem.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.7
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects
 import SddmComponents 2.0
 
 Item

--- a/slice/PagePower.qml
+++ b/slice/PagePower.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.7
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects
 import SddmComponents 2.0
 import QtQuick.Layouts 1.3
 


### PR DESCRIPTION
Fixes #15 

Simplest solution to enable functionality in Qt6, although Qt [recommends a rewrite](https://doc.qt.io/qt-6/graphicaleffects5.html) of afflicted code. 